### PR TITLE
Remove caching from image that is pulled

### DIFF
--- a/codeship-services.yml
+++ b/codeship-services.yml
@@ -12,7 +12,6 @@ services:
     environment:
       POSTGRES_USER: todoapp
       POSTGRES_DB: todos
-    cached: true
   deploy:
     image: codeship/heroku-deployment
     encrypted_env_file: deployment.env.encrypted


### PR DESCRIPTION
`cached: true` is meant for images that are built, not pulled.