### PR TITLE
Update service and step names to show they're example steps

### DIFF
--- a/codeship-services.yml
+++ b/codeship-services.yml
@@ -1,19 +1,17 @@
-version: '2'
-services:
-  web:
-    build: ./
-    links:
-      - postgres
-    environment:
-      DATABASE_URL: postgres://todoapp@postgres/todos
-    cached: true
-  postgres:
-    image: postgres:9.6.2-alpine
-    environment:
-      POSTGRES_USER: todoapp
-      POSTGRES_DB: todos
-  deploy:
-    image: codeship/heroku-deployment
-    encrypted_env_file: deployment.env.encrypted
-    volumes:
-      - ./:/deploy
+web_codeship_example:
+  build: ./
+  links:
+    - postgres
+  environment:
+    DATABASE_URL: postgres://todoapp@postgres/todos
+  cached: true
+postgres:
+  image: postgres:9.6.2-alpine
+  environment:
+    POSTGRES_USER: todoapp
+    POSTGRES_DB: todos
+deploy_codeship_example:
+  image: codeship/heroku-deployment
+  encrypted_env_file: deployment.env.encrypted
+  volumes:
+    - ./:/deploy

--- a/codeship-services.yml
+++ b/codeship-services.yml
@@ -1,4 +1,4 @@
-web_codeship_example:
+web_codeship_example_ruby:
   build: ./
   links:
     - postgres

--- a/codeship-services.yml
+++ b/codeship-services.yml
@@ -10,7 +10,7 @@ postgres:
   environment:
     POSTGRES_USER: todoapp
     POSTGRES_DB: todos
-deploy_codeship_example:
+codeship_heroku_deployment:
   image: codeship/heroku-deployment
   encrypted_env_file: deployment.env.encrypted
   volumes:

--- a/codeship-steps.yml
+++ b/codeship-steps.yml
@@ -10,9 +10,9 @@
       command: rubocop
   - name: deploy
     tag: master
-    service: deploy_codeship_example
+    service: codeship_heroku_deployment
     command: codeship_heroku deploy /deploy ruby-rails-todoapp
   - name: migrate
     tag: master
-    service: deploy_codeship_example
+    service: codeship_heroku_deployment
     command: heroku run --app ruby-rails-todoapp -- bundle exec rake db:migrate

--- a/codeship-steps.yml
+++ b/codeship-steps.yml
@@ -3,16 +3,16 @@
   - type: parallel
     steps:
     - name: rspec
-      service: web
+      service: web_codeship_example
       command: bin/ci rspec
     - name: rubocop
-      service: web
+      service: web_codeship_example
       command: rubocop
   - name: deploy
     tag: master
-    service: deploy
+    service: deploy_codeship_example
     command: codeship_heroku deploy /deploy ruby-rails-todoapp
   - name: migrate
     tag: master
-    service: deploy
+    service: deploy_codeship_example
     command: heroku run --app ruby-rails-todoapp -- bundle exec rake db:migrate

--- a/codeship-steps.yml
+++ b/codeship-steps.yml
@@ -3,10 +3,10 @@
   - type: parallel
     steps:
     - name: rspec
-      service: web_codeship_example
+      service: web_codeship_example_ruby
       command: bin/ci rspec
     - name: rubocop
-      service: web_codeship_example
+      service: web_codeship_example_ruby
       command: rubocop
   - name: deploy
     tag: master

--- a/codeship-steps.yml
+++ b/codeship-steps.yml
@@ -1,18 +1,16 @@
-- type: serial
+- type: parallel
   steps:
-  - type: parallel
-    steps:
-    - name: rspec
-      service: web_codeship_example_ruby
-      command: bin/ci rspec
-    - name: rubocop
-      service: web_codeship_example_ruby
-      command: rubocop
-  - name: deploy
-    tag: master
-    service: codeship_heroku_deployment
-    command: codeship_heroku deploy /deploy ruby-rails-todoapp
-  - name: migrate
-    tag: master
-    service: codeship_heroku_deployment
-    command: heroku run --app ruby-rails-todoapp -- bundle exec rake db:migrate
+  - name: rspec
+    service: web_codeship_example_ruby
+    command: bin/ci rspec
+  - name: rubocop
+    service: web_codeship_example_ruby
+    command: rubocop
+- name: deploy
+  tag: master
+  service: codeship_heroku_deployment
+  command: codeship_heroku deploy /deploy ruby-rails-todoapp
+- name: migrate
+  tag: master
+  service: codeship_heroku_deployment
+  command: heroku run --app ruby-rails-todoapp -- bundle exec rake db:migrate

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,8 @@ services:
       - .:/app
     ports:
       - "3000:3000"
+    depends_on:
+      - postgres
     environment:
       DATABASE_URL: postgres://todoapp@postgres/todos
   postgres:


### PR DESCRIPTION
- Updating service (non-dependency) and step names to show they're Codeship examples, in part so the output of `docker images` etc is a bit cleaner. Chose a suffix instead of a prefix so the identifiable information is first.
- Removing `version` and `services:` syntax in the services file (not sure I feel strongly about this, happy to revert if we don't think it's the right choice). While we support that syntax style to make it easier for users to copy/paste their Docker Compose services section, it isn't the "standard" services syntax.